### PR TITLE
See details

### DIFF
--- a/ship_it/__init__.py
+++ b/ship_it/__init__.py
@@ -40,7 +40,7 @@ def _package_virtualenv_with_manifest(manifest, requirements_file_path,
     """
     Given a manifest, package up the virtualenv. The following methods are
     supported via the manifest's `method` setting:
-    
+
     * copy: copy in the top-level directory
     * requirements: run ``pip install -r requirements_file``
         - useful if requirements_file contains '.' 
@@ -60,10 +60,10 @@ def _package_virtualenv_with_manifest(manifest, requirements_file_path,
 
     elif install_method == 'requirements':
         packager.install_requirements(requirements_file_path)
-    
+
     elif install_method == 'pip':    
         packager.pip_install_package(requirements_file_path)
-        
+
     else:
         packager.install_package(setup_py_path)
 

--- a/ship_it/__init__.py
+++ b/ship_it/__init__.py
@@ -3,7 +3,8 @@ from __future__ import unicode_literals
 from os import path
 
 from ship_it.manifest import Manifest, get_manifest_from_path
-from ship_it import virtualenv, cli
+from ship_it import cli
+from ship_it.virtualenv import VirtualEnvPackager
 
 
 def validate_path(path_to_check):
@@ -21,10 +22,11 @@ def fpm(manifest_path, requirements_file_path=None, setup_py_path=None,
 
     validate_path(manifest.path)
 
-    _package_virtualenv_with_manifest(manifest, requirements_file_path,
-                                      setup_py_path)
-    virtualenv.patch_virtualenv(manifest.local_virtualenv_path,
-                                manifest.remote_virtualenv_path)
+    packager = _package_virtualenv_with_manifest(manifest,
+                                                  requirements_file_path,
+                                                  setup_py_path)
+
+    packager.patch_virtualenv(manifest.remote_virtualenv_path)
 
     man_args, man_flags = manifest.get_args_and_flags()
     man_flags.extend(overrides.items())
@@ -36,18 +38,34 @@ def fpm(manifest_path, requirements_file_path=None, setup_py_path=None,
 def _package_virtualenv_with_manifest(manifest, requirements_file_path,
                                       setup_py_path):
     """
-    Given a manifest, package up the virtualenv, either by copying in the
-    top-level directory, or by installing it into the virtualenv with:
-    ``python setup.py install``. This is determined using the manifest's
-    "method" key, with the value "copy." Anything else will be considered an
-    install.
+    Given a manifest, package up the virtualenv. The following methods are
+    supported via the manifest's `method` setting:
+    
+    * copy: copy in the top-level directory
+    * requirements: run ``pip install -r requirements_file``
+        - useful if requirements_file contains '.' 
+    * pip: run ``pip install .``
+    * install (default): run ``python setup.py install``
     """
 
     venv = manifest.local_virtualenv_path
-    if manifest.contents.get('method') == 'copy':
-        virtualenv.copy_package_in_virtualenv(venv, requirements_file_path,
-                                              manifest.local_package_path)
-    else:
-        virtualenv.install_package_in_virtualenv(venv, setup_py_path)
+    install_method = manifest.contents.get('method')
 
+    # Buld virtualenv and optionally upgrade pip
+    packager = VirtualEnvPackager(venv, manifest.upgrade_pip)
+
+    if install_method == 'copy':
+        packager.copy_package(requirements_file_path,
+                                manifest.local_package_path)
+
+    elif install_method == 'requirements':
+        packager.install_requirements(requirements_file_path)
+    
+    elif install_method == 'pip':    
+        packager.pip_install_package(requirements_file_path)
+        
+    else:
+        packager.install_package(setup_py_path)
+
+    return packager
 

--- a/ship_it/manifest.py
+++ b/ship_it/manifest.py
@@ -116,6 +116,10 @@ class Manifest(object):
         return self.contents['name']
 
     @property
+    def upgrade_pip(self):
+        return bool(self.contents.get('upgrade_pip') is not None)
+
+    @property
     def virtualenv_name(self):
         return self.contents.setdefault('virtualenv_name',
                                         self.contents['name'])

--- a/ship_it/virtualenv.py
+++ b/ship_it/virtualenv.py
@@ -12,104 +12,132 @@ import fabric.api as fapi
 logger = logging.getLogger(__name__)
 
 
-def _validate_paths(virtualenv_path, setup_or_req_file):
+def _quote_and_vlidate_file(setup_or_req_file):
     """
-    Validate that both the virtualenv folder path and the "other file" is an
-    absolute path, additionally checking that the "other file" exists and is
-    a file.
+    Checking that the file exists, is absolute, and is a file.
+    Return quoted file
     """
-    assert path.isabs(virtualenv_path)
     assert path.isabs(setup_or_req_file) and path.isfile(setup_or_req_file)
+    return quote(setup_or_req_file)
+
+def _quote_and_validate_dir(dirpath):
+    """
+    Checking that the directory exists and is absolute
+    Return quoted directory
+    """
+    assert path.isabs(dirpath)
+    return quote(dirpath)
 
 
 def get_virtualenv():
     assert sys.executable, "can't infer python executable path"
     return '{} -m virtualenv'.format(quote(sys.executable))
 
+class VirtualEnvPackager(object):
 
-def _build_virtualenv(virtualenv_path):
-    """
-    :param virtualenv_path: the path to the virtualenv we're going to make
-    :return: the quoted-for-cli virtualenv_path
-    """
-    # in case there's relevant escape characters
-    venv_path = quote(virtualenv_path)
+    def __init__(self, virtualenv_path, upgrade_pip=False):
+        self.virtualenv_path = virtualenv_path
+        self.build_virtualenv(virtualenv_path, upgrade_pip)
 
-    if path.exists(virtualenv_path):
-        fapi.local('rm -rf {}'.format(venv_path))
+    def build_virtualenv(self, virtualenv_path, upgrade_pip):
+        """
+        :param virtualenv_path: the path to the virtualenv we're going to make
+        :return: the quoted-for-cli virtualenv_path
+        """
+        quoted_path = _quote_and_validate_dir(virtualenv_path)
+    
+        if path.exists(virtualenv_path):
+            fapi.local('rm -rf {}'.format(quoted_path))
+    
+        fapi.local('{virtualenv} {location}'.format(virtualenv=get_virtualenv(),
+                                                    location=quoted_path))
+        if upgrade_pip:
+            fapi.local('{pip} install --upgrade pip'
+                       ''.format(pip=quote(path.join(virtualenv_path,
+                                                     'bin', 'pip'))))
+    
+    def run_venv_command(self, command, arg_list):
+        args = ' '.join(arg_list)
+        command = quote(path.join(self.virtualenv_path,
+                            'bin', command))
+        fapi.local('{command} {args}'.format(command=command,
+                                             args=args))
 
-    fapi.local('{virtualenv} {location}'.format(virtualenv=get_virtualenv(),
-                                                location=venv_path))
-    return venv_path
+    def install_package(self, setup_py_path):
+        """
+        Run package's setup.py install
+        """
+        setup_file = _quote_and_vlidate_file(setup_py_path)
+    
+        # we're going to install our package into the app
+        # this should ensure everything is installed, and respect any environment
+        # variables that fabric was invoked with (notably custom paths)
+        self.run_venv_command('python', [setup_file, 'install'])
 
+    def install_requirements(self, requirements_file_path):
+        """
+        Package installation is provided by requirements.txt
+        """
+        req_file = _quote_and_vlidate_file(requirements_file_path)
+        self.run_venv_command('pip', ['install', '-r', req_file])
 
-def install_package_in_virtualenv(virtualenv_path, setup_py_path):
-    _validate_paths(virtualenv_path, setup_py_path)
-
-    venv_path = _build_virtualenv(virtualenv_path)
-    # we're going to install our package into the app
-    # this should ensure everything is installed, and respect any environment
-    # variables that fabric was invoked with (notably custom paths)
-    setup_file = quote(setup_py_path)
-    fapi.local('{venv}/bin/python {setup} install'.format(venv=venv_path,
-                                                          setup=setup_file))
-
-
-def copy_package_in_virtualenv(virtualenv_path, requirements_file_path,
-                               package_path):
-    """
-    :param virtualenv_path: the path to the virtualenv directory (e.g. has
-        the bin/lib folders)
-    :param requirements_file_path: the path to the requirements.txt file
-    :param package_path: the path to the package we're going to copy into
-        the virtualenv
-    """
-    _validate_paths(virtualenv_path, requirements_file_path)
-    req_file = quote(requirements_file_path)
-    pkg_path = quote(package_path)
-
-    venv_path = _build_virtualenv(virtualenv_path)
-    # this should ensure everything is installed, and respect any environment
-    # variables that fabric was invoked with (notably custom paths)
-    fapi.local('{venv}/bin/pip install -r {req}'.format(venv=venv_path,
-                                                        req=req_file))
-    fapi.local('find {pkg} -type f -name "*.py[co]" -delete;'
-               'find {pkg} -type d -name "__pycache__" -delete'.format(
-                pkg=pkg_path))
-    fapi.local('cp -r {} {}'.format(quote(pkg_path.rstrip('/')),
-                                    venv_path))
-
-
-def patch_virtualenv(virtualenv_path, destination_path):
-    """
-    Patch the virtualenv we built to be relocatable and
-
-    :param virtualenv_path: the local path to you virtualenv
-    :param destination_path: the path you expect it to be in the resulting
-        system
-    """
-    remove_prelink_if_applicable(virtualenv_path)
-
-    fapi.local('{virtualenv} --relocatable {local_path}'.format(
-        virtualenv=get_virtualenv(), local_path=quote(virtualenv_path)
-    ))
-
-    # the activate script isn't handled by doing --relocatable
-    fapi.local('sed -i "s:{local}:{dest}:" {local_activate}'.format(
-        local=virtualenv_path, dest=destination_path,
-        local_activate=quote(path.join(virtualenv_path, 'bin', 'activate'))))
+    def pip_install_package(self, requirements_file_path):
+        """
+        Install local package from '.' using pip
+        """
+        self.install_requirements(requirements_file_path)
+        self.run_venv_command('pip', ['install', '.'])
 
 
-def remove_prelink_if_applicable(virtualenv_path):
-    """
-    Packaging a virtualenv has issues if you prelink the executables. Ideally,
-    Prelink would be uninstalled on the system, but if it is, we need to undo
-    it for our python.
-    """
-    try:
-        fapi.local('prelink -u {}'.format(quote(path.join(virtualenv_path,
-                                                          'bin', 'python'))))
-    except:
-        # We're assuming that if it didn't work, then prelink must not be
-        # installed, or at least not relevant for us.
-        logger.debug('prelink not undone due to error', exc_info=True)
+    def copy_package(self, requirements_file_path, package_path):
+        """
+        :param virtualenv_path: the path to the virtualenv directory (e.g. has
+            the bin/lib folders)
+        :param requirements_file_path: the path to the requirements.txt file
+        :param package_path: the path to the package we're going to copy into
+            the virtualenv
+        """
+        req_file = _quote_and_vlidate_file(requirements_file_path)
+        pkg_path = _quote_and_validate_dir(package_path)
+
+        self.run_venv_command('pip', ['install', '-r', req_file])
+
+        fapi.local('find {pkg} -type f -name "*.py[co]" -delete;'
+                   'find {pkg} -type d -name "__pycache__" -delete'.format(
+                    pkg=pkg_path))
+        fapi.local('cp -r {} {}'.format(quote(package_path.rstrip('/')),
+                                        quote(self.virtualenv_path)))
+
+
+    def patch_virtualenv(self, destination_path):
+        """
+        Patch the virtualenv we built to be relocatable and
+    
+        :param destination_path: the path you expect it to be in the resulting
+            system
+        """
+        self.remove_prelink_if_applicable()
+    
+        fapi.local('{virtualenv} --relocatable {local_path}'.format(
+            virtualenv=get_virtualenv(), local_path=quote(self.virtualenv_path)
+        ))
+    
+        # the activate script isn't handled by doing --relocatable
+        fapi.local('sed -i "s:{local}:{dest}:" {local_activate}'.format(
+            local=self.virtualenv_path, dest=destination_path,
+            local_activate=quote(path.join(self.virtualenv_path, 'bin', 'activate'))))
+    
+    
+    def remove_prelink_if_applicable(self):
+        """
+        Packaging a virtualenv has issues if you prelink the executables. Ideally,
+        Prelink would be uninstalled on the system, but if it is, we need to undo
+        it for our python.
+        """
+        try:
+            fapi.local('prelink -u {}'.format(quote(path.join(self.virtualenv_path,
+                                                              'bin', 'python'))))
+        except:
+            # We're assuming that if it didn't work, then prelink must not be
+            # installed, or at least not relevant for us.
+            logger.debug('prelink not undone due to error', exc_info=True)

--- a/tests/test_full_invocation.py
+++ b/tests/test_full_invocation.py
@@ -8,8 +8,8 @@ import pytest
 import ship_it
 
 
-@mock.patch('ship_it.virtualenv.patch_virtualenv')
-@mock.patch('ship_it._package_virtualenv_with_manifest')
+@mock.patch('ship_it.VirtualEnvPackager.patch_virtualenv')
+@mock.patch('ship_it._package_virtualenv_with_manifest', return_value=ship_it.virtualenv.VirtualEnvPackager)
 @mock.patch('ship_it.validate_path')
 @mock.patch('ship_it.cli.invoke_fpm')
 @mock.patch('ship_it.Manifest.get_args_and_flags',
@@ -58,18 +58,16 @@ class TestCallingTheRightPackaging(object):
     function.
     """
     @pytest.mark.parametrize('man_fixture', ['manifest', 'install_manifest'])
-    @mock.patch('ship_it.virtualenv.install_package_in_virtualenv')
+    @mock.patch('ship_it.virtualenv.VirtualEnvPackager.install_package')
     def test_installing(self, mock_install, request, man_fixture):
         the_manifest = request.getfuncargvalue(man_fixture)
         assert not mock_install.called
         ship_it._package_virtualenv_with_manifest(the_manifest, 'req', 'set')
-        mock_install.assert_called_once_with(
-            the_manifest.local_virtualenv_path, 'set')
+        mock_install.assert_called_once_with('set')
 
-    @mock.patch('ship_it.virtualenv.copy_package_in_virtualenv')
+    @mock.patch('ship_it.virtualenv.VirtualEnvPackager.copy_package')
     def test_copying(self, mock_copy, copy_manifest):
         assert not mock_copy.called
         ship_it._package_virtualenv_with_manifest(copy_manifest, 'req', 'set')
-        mock_copy.assert_called_once_with(copy_manifest.local_virtualenv_path,
-                                          'req',
+        mock_copy.assert_called_once_with('req',
                                           copy_manifest.local_package_path)

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -112,6 +112,24 @@ def test_override_virtualenv_name():
     assert test_man.name == 'prefix-ship_it'
 
 
+@pytest.mark.parametrize('val,expected', [
+    ('true', True),
+    ('1', True),
+    ('1', True),
+    ('0', True),
+    ('', True),
+    (None, False),
+])
+def test_upgrade_pip(val, expected):
+    """
+    Test that upgrade pip is available
+    """
+    test_man = Manifest('manifest.yaml', manifest_contents=dict(
+        upgrade_pip=val
+    ))
+    assert test_man.upgrade_pip is expected
+
+
 class TestPackagePath(object):
     """
     Test things related to figuring out the package path

--- a/tests/test_virtualenv.py
+++ b/tests/test_virtualenv.py
@@ -5,15 +5,27 @@ from pipes import quote
 
 import mock
 import pytest
+from tempfile import mkdtemp
 
-from ship_it import virtualenv
+from ship_it.virtualenv import VirtualEnvPackager
 
 @pytest.fixture(autouse=True)
 def patch_executable(monkeypatch):
     monkeypatch.setattr('sys.executable', '/path/to/python.py')
 
 
+@pytest.yield_fixture
+def mock_build_venv():
+    with mock.patch('ship_it.virtualenv.VirtualEnvPackager.build_virtualenv') as _m:
+        yield _m
+
+
 class TestPackage(object):
+
+    @pytest.yield_fixture(autouse=True)
+    def do_not_build(self, mock_build_venv):
+        yield
+
     @pytest.fixture(autouse=True)
     def make_files_exist_and_be_absolute(self, monkeypatch):
         always_true = lambda *args, **kwargs: True
@@ -35,13 +47,10 @@ class TestPackage(object):
             'cp -r /local/pkg /local/venv/path',
         ]),
     ])
-    def test_copying_a_packaging_into_virtualenv(self, mock_local, venv,
-                                                 pkg_dir, req, expected):
+    def test_copy_package(self, mock_local, venv, pkg_dir, req, expected):
 
         assert not mock_local.called
-        with mock.patch('ship_it.virtualenv._build_virtualenv',
-                        return_value=quote(venv)):
-            virtualenv.copy_package_in_virtualenv(venv, req, pkg_dir)
+        VirtualEnvPackager(venv).copy_package(req, pkg_dir)
 
         assert mock_local.mock_calls == [mock.call(exp) for exp in expected]
 
@@ -49,42 +58,81 @@ class TestPackage(object):
         ('/local/venv/path', '/local/setup.py',
          '/local/venv/path/bin/python /local/setup.py install'),
     ])
-    def test_installing_a_packaging_into_virtualenv(self, mock_local, venv,
-                                                    setup, expected):
+    def test_install_package(self, mock_local, venv, setup, expected):
         assert not mock_local.called
-        with mock.patch('ship_it.virtualenv._build_virtualenv',
-                        return_value=quote(venv)):
-            virtualenv.install_package_in_virtualenv(venv, setup)
+        VirtualEnvPackager(venv).install_package(setup)
+        mock_local.assert_called_once_with(expected)
 
+    @pytest.mark.parametrize('venv,req,expected', [
+        ('/local/venv/path', '/local/reqs.txt',
+         '/local/venv/path/bin/pip install -r /local/reqs.txt'),
+    ])
+    def test_install_requirements(self, mock_local, venv, req, expected):
+        assert not mock_local.called
+        VirtualEnvPackager(venv).install_requirements(req)
+        mock_local.assert_called_once_with(expected)
+
+    @pytest.mark.parametrize('venv,req,expected', [
+        ('/local/venv/path', '/local/reqs.txt',
+         '/local/venv/path/bin/pip install .'),
+    ])
+    def test_pip_install(self, mock_local, venv, req, expected):
+        assert mock_local.mock_calls == []
+        with mock.patch('ship_it.virtualenv.VirtualEnvPackager.'
+                        'install_requirements') as mock_install_reqs:
+            VirtualEnvPackager(venv).pip_install_package(req)
+            mock_install_reqs.assert_called_once_with(req)
         mock_local.assert_called_once_with(expected)
 
 
-@pytest.mark.parametrize('exists', [True, False])
-def test_building_the_virtualenv(exists, mock_local):
-    assert not mock_local.called
-    with mock.patch('ship_it.virtualenv.path.exists', return_value=exists):
-        virtualenv._build_virtualenv('/my/local path/to/venv')
+class TestBuildVirtualEnv(object):
 
-    if exists:
-        # We expect that we're going to delete the directory
-        rm_rf_call = [mock.call("rm -rf '/my/local path/to/venv'")]
-    else:
-        # We don't need to do that
-        rm_rf_call = []
+    @pytest.mark.parametrize('exists', [True, False])
+    def test_exists(self, exists, mock_local):
+        assert not mock_local.called
+        with mock.patch('ship_it.virtualenv.path.exists', return_value=exists):
+            VirtualEnvPackager('/my/local path/to/venv')
+    
+        if exists:
+            # We expect that we're going to delete the directory
+            rm_rf_call = [mock.call("rm -rf '/my/local path/to/venv'")]
+        else:
+            # We don't need to do that
+            rm_rf_call = []
+    
+        assert mock_local.mock_calls == rm_rf_call + [
+            mock.call("/path/to/python.py -m virtualenv '/my/local path/to/venv'")
+        ]
 
-    assert mock_local.mock_calls == rm_rf_call + [
-        mock.call("/path/to/python.py -m virtualenv '/my/local path/to/venv'")
-    ]
+    @pytest.mark.parametrize('upgrade_pip', [True, False])
+    def test_upgrade_pip(self, upgrade_pip, mock_local):
+        assert mock_local.mock_calls == []
+        pkger = VirtualEnvPackager('/tmp/foo', upgrade_pip)
+
+        if upgrade_pip:
+            upgrade_pip_call = [mock.call('/tmp/foo/bin/pip install --upgrade pip')]
+        else:
+            upgrade_pip_call = []
+        assert mock_local.mock_calls == [
+            mock.call("/path/to/python.py -m virtualenv /tmp/foo")
+        ] + upgrade_pip_call
 
 
 class TestPatchVirtualEnv(object):
+
+    @pytest.yield_fixture(autouse=True)
+    def do_not_build(self, mock_build_venv):
+        yield
+
     def test_with_no_spaces(self, monkeypatch, mock_local):
         monkeypatch.setattr('sys.executable', '/some/python.py')
 
         local_venv = '/local/venv'
         remote_venv = '/remote/venv'
+        pkger = VirtualEnvPackager(local_venv)
+        mock_local.reset_mock()
         assert not mock_local.called
-        virtualenv.patch_virtualenv(local_venv, remote_venv)
+        pkger.patch_virtualenv(remote_venv)
         assert mock_local.mock_calls == [
             mock.call('prelink -u /local/venv/bin/python'),
             mock.call('/some/python.py -m virtualenv '
@@ -98,8 +146,10 @@ class TestPatchVirtualEnv(object):
 
         local_venv = '/local path/venv'
         remote_venv = '/remote path/venv'
+        pkger = VirtualEnvPackager(local_venv)
+        mock_local.reset_mock()
         assert not mock_local.called
-        virtualenv.patch_virtualenv(local_venv, remote_venv)
+        pkger.patch_virtualenv(remote_venv)
         assert mock_local.mock_calls == [
             mock.call("prelink -u '/local path/venv/bin/python'"),
             mock.call("/some/python.py -m virtualenv --relocatable "
@@ -110,11 +160,14 @@ class TestPatchVirtualEnv(object):
 
 
 @mock.patch('ship_it.virtualenv.logger')
-def test_handle_prelink_issue(mock_logger, mock_local):
+def test_handle_prelink_issue(mock_logger, mock_local, mock_build_venv):
+    pkger = VirtualEnvPackager('/tmp')
+    mock_local.reset_mock()
+    mock_logger.reset_mock()
     assert not mock_local.called
     assert not mock_logger.called
     mock_local.side_effect = Exception
-    virtualenv.remove_prelink_if_applicable('some path')
+    pkger.remove_prelink_if_applicable()
     mock_logger.debug.assert_called_once_with(
         'prelink not undone due to error', exc_info=True)
 
@@ -128,14 +181,13 @@ def test_handle_prelink_issue(mock_logger, mock_local):
     ('/some/fake/absolute/path/to/directory', False),
     ('/some/fake/absolute/path/to/requirements.txt', False)
 ])
-def test_handle_odd_reqfile_paths(req_file_path, valid):
+def test_handle_odd_reqfile_paths(req_file_path, valid, mock_build_venv):
 
-    args = '/some/path', req_file_path, '/other/path'
     if not valid:
         with pytest.raises(AssertionError):
-            virtualenv.copy_package_in_virtualenv(*args)
+            VirtualEnvPackager('/tmp').copy_package(req_file_path, '/other/path')
     else:
-        virtualenv.copy_package_in_virtualenv(*args)
+        VirtualEnvPackager('/tmp').copy_package(req_file_path, '/other/path')
 
 @pytest.mark.parametrize('setup_path, valid', [
     # convenient way to get an absolute path that exists
@@ -146,9 +198,10 @@ def test_handle_odd_reqfile_paths(req_file_path, valid):
     ('/some/fake/absolute/path/to/directory', False),
     ('/some/fake/absolute/path/to/setup.py', False)
 ])
-def test_handle_odd_setup_paths(setup_path, valid):
+def test_handle_odd_setup_paths(setup_path, valid, mock_build_venv):
+    pkger = VirtualEnvPackager('/tmp')
     if not valid:
         with pytest.raises(AssertionError):
-            virtualenv.install_package_in_virtualenv('/some/path', setup_path)
+            pkger.install_package(setup_path)
     else:
-        virtualenv.install_package_in_virtualenv('/some/path', setup_path)
+        pkger.install_package(setup_path)

--- a/tests/test_virtualenv.py
+++ b/tests/test_virtualenv.py
@@ -92,14 +92,14 @@ class TestBuildVirtualEnv(object):
         assert not mock_local.called
         with mock.patch('ship_it.virtualenv.path.exists', return_value=exists):
             VirtualEnvPackager('/my/local path/to/venv')
-    
+
         if exists:
             # We expect that we're going to delete the directory
             rm_rf_call = [mock.call("rm -rf '/my/local path/to/venv'")]
         else:
             # We don't need to do that
             rm_rf_call = []
-    
+
         assert mock_local.mock_calls == rm_rf_call + [
             mock.call("/path/to/python.py -m virtualenv '/my/local path/to/venv'")
         ]


### PR DESCRIPTION
Add upgrade_pip manifest option to upgrade virtualenv's pip
Add 'requirements' install method
Add 'pip' install method

Reasons:
The default pip in some virtualenvs is VERY old.
``pip install .`` over ``python setup.py install`` takes advantage of pip wheel cache and settings
Sometimes requirements.txt contains ``.``, which makes any subsequent install methods pointless.