### PR TITLE
Add excludes option to manifest parser

### DIFF
--- a/ship_it/manifest.py
+++ b/ship_it/manifest.py
@@ -102,6 +102,12 @@ class Manifest(object):
 
         return flags.items()
 
+    def get_bool_value(self, name):
+        """
+        Get manifest value `name` as a boolean
+        """
+        return bool(self.contents.get(name, '').lower() in ['true', 'yes', 'on', 'y'])
+
     def get_dependency_flags(self):
         """
         get all the flags related to dependencies
@@ -110,9 +116,13 @@ class Manifest(object):
 
     def get_exclude_flags(self):
         """
-        get all the excludes defined in manifest
+        Get all the excludes defined in manifest. Optionally add '*.py[co]' and
+        '__pycache__' if exclude_compiled is set. 
         """
-        return [('exclude', excl) for excl in self.contents.get('excludes', [])]
+        excludes = set([('exclude', excl) for excl in self.contents.get('exclude', [])])
+        if self.get_bool_value('exclude_compiled'):
+            excludes |= set([('exclude', excl) for excl in ['*.py[co]', '__pycache__']])
+        return excludes
 
     @property
     def manifest_dir(self):
@@ -124,7 +134,7 @@ class Manifest(object):
 
     @property
     def upgrade_pip(self):
-        return bool(self.contents.get('upgrade_pip') is not None)
+        return self.get_bool_value('upgrade_pip')
 
     @property
     def virtualenv_name(self):

--- a/ship_it/manifest.py
+++ b/ship_it/manifest.py
@@ -60,6 +60,7 @@ class Manifest(object):
         args.extend(cfg_args)
         flags.extend(cfg_flags)
         flags.extend(self.get_dependency_flags())
+        flags.extend(self.get_exclude_flags())
 
         return args, flags
 
@@ -106,6 +107,12 @@ class Manifest(object):
         get all the flags related to dependencies
         """
         return [('depends', dep) for dep in self.contents.get('depends', [])]
+
+    def get_exclude_flags(self):
+        """
+        get all the excludes defined in manifest
+        """
+        return [('exclude', excl) for excl in self.contents.get('excludes', [])]
 
     @property
     def manifest_dir(self):


### PR DESCRIPTION
fpm: "--exclude EXCLUDE_PATTERN Exclude paths matching pattern (shell wildcard globs valid here). If you have multiple file patterns to exclude, specify this flag multiple times."