### PR TITLE
adding ability to upgrade wheel after building virtualenv

### DIFF
--- a/ship_it/__init__.py
+++ b/ship_it/__init__.py
@@ -43,7 +43,7 @@ def _package_virtualenv_with_manifest(manifest, requirements_file_path,
 
     * copy: copy in the top-level directory
     * requirements: run ``pip install -r requirements_file``
-        - useful if requirements_file contains '.' 
+        - useful if requirements_file contains '.'
     * pip: run ``pip install .``
     * install (default): run ``python setup.py install``
     """
@@ -52,7 +52,7 @@ def _package_virtualenv_with_manifest(manifest, requirements_file_path,
     install_method = manifest.contents.get('method')
 
     # Buld virtualenv and optionally upgrade pip
-    packager = VirtualEnvPackager(venv, manifest.upgrade_pip)
+    packager = VirtualEnvPackager(venv, manifest.upgrade_pip, manifest.upgrade_wheel)
 
     if install_method == 'copy':
         packager.copy_package(requirements_file_path,
@@ -61,7 +61,7 @@ def _package_virtualenv_with_manifest(manifest, requirements_file_path,
     elif install_method == 'requirements':
         packager.install_requirements(requirements_file_path)
 
-    elif install_method == 'pip':    
+    elif install_method == 'pip':
         packager.pip_install_package(requirements_file_path)
 
     else:

--- a/ship_it/manifest.py
+++ b/ship_it/manifest.py
@@ -136,6 +136,10 @@ class Manifest(object):
         return self.get_bool_value('upgrade_pip')
 
     @property
+    def upgrade_wheel(self):
+        return self.get_bool_value('upgrade_wheel')
+
+    @property
     def virtualenv_name(self):
         return self.contents.setdefault('virtualenv_name',
                                         self.contents['name'])

--- a/ship_it/virtualenv.py
+++ b/ship_it/virtualenv.py
@@ -36,18 +36,20 @@ def get_virtualenv():
 
 class VirtualEnvPackager(object):
 
-    def __init__(self, virtualenv_path, upgrade_pip=False):
+    def __init__(self, virtualenv_path, upgrade_pip=False, upgrade_wheel=False):
         """
         :param virtualenv_path: the path to the virtualenv we're going to make
         :param upgrade_pip: upgrade pip after building virtualenv
+        :param upgrade_wheel: upgrade wheel after building virtualenv
         """
         self.virtualenv_path = virtualenv_path
-        self.build_virtualenv(virtualenv_path, upgrade_pip)
+        self.build_virtualenv(virtualenv_path, upgrade_pip, upgrade_wheel)
 
-    def build_virtualenv(self, virtualenv_path, upgrade_pip):
+    def build_virtualenv(self, virtualenv_path, upgrade_pip, upgrade_wheel):
         """
         :param virtualenv_path: the path to the virtualenv we're going to make
         :param upgrade_pip: upgrade pip after building virtualenv
+        :param upgrade_wheel: upgrade wheel after building virtualenv
         """
         quoted_path = _quote_and_validate_dir(virtualenv_path)
 
@@ -58,6 +60,11 @@ class VirtualEnvPackager(object):
                                                     location=quoted_path))
         if upgrade_pip:
             invoke.run('{pip} install --upgrade pip'
+                       ''.format(pip=quote(path.join(virtualenv_path,
+                                                     'bin', 'pip'))))
+
+        if upgrade_wheel:
+            invoke.run('{pip} install --upgrade wheel'
                        ''.format(pip=quote(path.join(virtualenv_path,
                                                      'bin', 'pip'))))
 

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -132,6 +132,22 @@ def test_upgrade_pip(val, expected):
     ))
     assert test_man.upgrade_pip is expected
 
+@pytest.mark.parametrize('val,expected', [
+    ('true', True),
+    ('yes', True),
+    ('on', True),
+    ('y', True),
+    ('', False),
+    ('false', False),
+])
+def test_upgrade_wheel(val, expected):
+    """
+    Test that upgrade wheel is available
+    """
+    test_man = Manifest('manifest.yaml', manifest_contents=dict(
+        upgrade_wheel=val
+    ))
+    assert test_man.upgrade_wheel is expected
 
 class TestPackagePath(object):
     """

--- a/tests/test_virtualenv.py
+++ b/tests/test_virtualenv.py
@@ -107,7 +107,7 @@ class TestBuildVirtualEnv(object):
     @pytest.mark.parametrize('upgrade_pip', [True, False])
     def test_upgrade_pip(self, upgrade_pip, mock_local):
         assert mock_local.mock_calls == []
-        pkger = VirtualEnvPackager('/tmp/foo', upgrade_pip)
+        pkger = VirtualEnvPackager('/tmp/foo', upgrade_pip, False)
 
         if upgrade_pip:
             upgrade_pip_call = [mock.call('/tmp/foo/bin/pip install --upgrade pip')]
@@ -117,6 +117,18 @@ class TestBuildVirtualEnv(object):
             mock.call("/path/to/python.py -m virtualenv /tmp/foo")
         ] + upgrade_pip_call
 
+    @pytest.mark.parametrize('upgrade_wheel', [True, False])
+    def test_upgrade_wheel(self, upgrade_wheel, mock_local):
+        assert mock_local.mock_calls == []
+        pkger = VirtualEnvPackager('/tmp/foo', False, upgrade_wheel)
+
+        if upgrade_wheel:
+            upgrade_wheel_call = [mock.call('/tmp/foo/bin/pip install --upgrade wheel')]
+        else:
+            upgrade_wheel_call = []
+        assert mock_local.mock_calls == [
+            mock.call("/path/to/python.py -m virtualenv /tmp/foo")
+        ] + upgrade_wheel_call
 
 class TestPatchVirtualEnv(object):
 


### PR DESCRIPTION
Along with the pathing issue I saw in #12 for Python3.5, I also ran into AssertionErrors when trying to install some pip packages. 

Sample error for psycopg2:
```
  Copying psycopg2.egg-info to build/bdist.linux-x86_64/wheel/psycopg2-2.6.2-py3.5.egg-info
  running install_scripts
  Traceback (most recent call last):
    File "<string>", line 1, in <module>
    File "/tmp/pip-build-0wcxdzk8/psycopg2/setup.py", line 624, in <module>
      ext_modules=ext)
    File "/opt/rh/rh-python35/root/usr/lib64/python3.5/distutils/core.py", line 148, in setup
      dist.run_commands()
    File "/opt/rh/rh-python35/root/usr/lib64/python3.5/distutils/dist.py", line 955, in run_commands
      self.run_command(cmd)
    File "/opt/rh/rh-python35/root/usr/lib64/python3.5/distutils/dist.py", line 974, in run_command
      cmd_obj.run()
    File "/src/build/metrics-reporting/lib/python3.5/site-packages/wheel/bdist_wheel.py", line 213, in run
      archive_basename = self.get_archive_basename()
    File "/src/build/metrics-reporting/lib/python3.5/site-packages/wheel/bdist_wheel.py", line 161, in get_archive_basename
      impl_tag, abi_tag, plat_tag = self.get_tag()
    File "/src/build/metrics-reporting/lib/python3.5/site-packages/wheel/bdist_wheel.py", line 155, in get_tag
      assert tag == supported_tags[0]
  AssertionError
```

I came across this thread: https://bitbucket.org/pypa/wheel/issues/146/wheel-building-fails-on-cpython-350b3 which suggested an issue with an outdated wheel. To resolve this issue, I have added an upgrade_wheel variable in the manifest which will allow a wheel update before any other packages gets installed. 

A successful run (with `upgrade_wheel=true` in `manifest.yaml`):
```
bash-4.2# /opt/rh/rh-python35/root/usr/bin/ship_it manifest.yaml
Using base prefix '/opt/rh/rh-python35/root/usr'
New python executable in /src/build/metrics-reporting/bin/python3
Also creating executable in /src/build/metrics-reporting/bin/python
Installing setuptools, pip, wheel...done.
Collecting pip
  Downloading https://foo.bar.com/artifactory/api/pypi/aggregate-pypi/packages/b6/ac/7015eb97dc749283ffdec1c3a88ddb8ae03b8fad0f0e611408f196358da3/pip-9.0.1-py2.py3-none-any.whl (1.3MB)
Installing collected packages: pip
  Found existing installation: pip 7.1.2
    Uninstalling pip-7.1.2:
      Successfully uninstalled pip-7.1.2
Successfully installed pip-9.0.1
Collecting wheel
  Downloading https://foo.bar.com/artifactory/api/pypi/aggregate-pypi/packages/8a/e9/8468cd68b582b06ef554be0b96b59f59779627131aad48f8a5bce4b13450/wheel-0.29.0-py2.py3-none-any.whl (66kB)
Installing collected packages: wheel
  Found existing installation: wheel 0.24.0
    Uninstalling wheel-0.24.0:
      Successfully uninstalled wheel-0.24.0
Successfully installed wheel-0.29.0
Collecting requests[security]==2.9.2 (from -r /src/requirements.txt (line 1))
  Downloading https://foo.bar.com/artifactory/api/pypi/aggregate-pypi/packages/8b/e7/229a428b8eb9a7f925ef16ff09ab25856efe789410d661f10157919f2ae2/requests-2.9.2-py2.py3-none-any.whl (502kB)
Collecting jira (from -r /src/requirements.txt (line 2))
  Downloading https://foo.bar.com/artifactory/api/pypi/aggregate-pypi/packages/ef/70/f779824bf23a9a8122d4df2644ef518a5a86d548a2e0a9ab9e3adcb290d0/jira-1.0.7-py2.py3-none-any.whl (58kB)
Collecting configargparse (from -r /src/requirements.txt (line 3))
  Downloading https://foo.bar.com/artifactory/api/pypi/aggregate-pypi/packages/45/87/a815edcdc867de0964e5f1efef6db956bbb6fe77dbe3f273f2aeab39cbe8/ConfigArgParse-0.11.0.tar.gz (40kB)
Collecting pyopenssl (from -r /src/requirements.txt (line 4))
  Downloading https://foo.bar.com/artifactory/api/pypi/aggregate-pypi/packages/ac/93/b4cd538d31adacd07f83013860db6b88d78755af1f3fefe68ec22d397e7b/pyOpenSSL-16.2.0-py2.py3-none-any.whl (43kB)
Collecting pycrypto (from -r /src/requirements.txt (line 5))
  Downloading https://foo.bar.com/artifactory/api/pypi/aggregate-pypi/packages/60/db/645aa9af249f059cc3a368b118de33889219e0362141e75d4eaf6f80f163/pycrypto-2.6.1.tar.gz (446kB)
Collecting urllib3[secure] (from -r /src/requirements.txt (line 6))
  Downloading https://foo.bar.com/artifactory/api/pypi/aggregate-pypi/packages/ff/45/7b5d82c483634b6b4cd94392a07c94d36255402286098b7fb10b6cb88e6a/urllib3-1.19.1-py2.py3-none-any.whl (104kB)
Collecting pyasn1 (from -r /src/requirements.txt (line 7))
  Downloading https://foo.bar.com/artifactory/api/pypi/aggregate-pypi/packages/69/be/e8946f7867b84b0e61a613f6fd56f63266190b1a470f945178f7cbc4d0ae/pyasn1-0.1.9-py2.py3-none-any.whl
Collecting ndg-httpsclient (from -r /src/requirements.txt (line 8))
  Downloading https://foo.bar.com/artifactory/api/pypi/aggregate-pypi/packages/a2/a7/ad1c1c48e35dc7545dab1a9c5513f49d5fa3b5015627200d2be27576c2a0/ndg_httpsclient-0.4.2.tar.gz
Collecting requests_jwt (from -r /src/requirements.txt (line 9))
  Downloading https://foo.bar.com/artifactory/api/pypi/aggregate-pypi/packages/0f/a5/6427719742b48706a46b36c6f63614a33ac6761af191e86b90e99bf2d64c/requests-jwt-0.4.tar.gz
Collecting psycopg2 (from -r /src/requirements.txt (line 10))
  Downloading https://foo.bar.com/artifactory/api/pypi/aggregate-pypi/packages/7b/a8/dc2d50a6f37c157459cd18bab381c8e6134b9381b50fbe969997b2ae7dbc/psycopg2-2.6.2.tar.gz (376kB)
Collecting six>=1.9.0 (from jira->-r /src/requirements.txt (line 2))
  Downloading https://foo.bar.com/artifactory/api/pypi/aggregate-pypi/packages/c8/0a/b6723e1bc4c516cb687841499455a8505b44607ab535be01091c0f24f079/six-1.10.0-py2.py3-none-any.whl
Collecting requests-toolbelt (from jira->-r /src/requirements.txt (line 2))
  Downloading https://foo.bar.com/artifactory/api/pypi/aggregate-pypi/packages/57/60/cc85ca45c85585191e70e21687aeaa74ec4e555a1404628ba77b8af7d92e/requests_toolbelt-0.7.0-py2.py3-none-any.whl (52kB)
Collecting requests-oauthlib>=0.3.3 (from jira->-r /src/requirements.txt (line 2))
  Downloading https://foo.bar.com/artifactory/api/pypi/aggregate-pypi/packages/ff/2c/efaf0fdea8a6979d0ebee360771418345f1f0906bd478a908256df63ff51/requests_oauthlib-0.7.0-py2.py3-none-any.whl
Collecting tlslite>=0.4.4 (from jira->-r /src/requirements.txt (line 2))
  Downloading https://foo.bar.com/artifactory/api/pypi/aggregate-pypi/packages/92/2b/7904cf913d9bf150b3e408a92c9cb5ce0b97a9ec19f998af48bf4c607f0e/tlslite-0.4.9.tar.gz (105kB)
Collecting cryptography>=1.3.4 (from pyopenssl->-r /src/requirements.txt (line 4))
  Downloading https://foo.bar.com/artifactory/api/pypi/aggregate-pypi/packages/6c/c5/7fc1f8384443abd2d71631ead026eb59863a58cad0149b94b89f08c8002f/cryptography-1.5.3.tar.gz (400kB)
Collecting certifi; extra == "secure" (from urllib3[secure]->-r /src/requirements.txt (line 6))
  Downloading https://foo.bar.com/artifactory/api/pypi/aggregate-pypi/packages/a2/35/b7b457c95fdd661d4c179201e9e58a2181934695943b08ccfcba09284b4e/certifi-2016.9.26-py2.py3-none-any.whl (377kB)
Collecting PyJWT (from requests_jwt->-r /src/requirements.txt (line 9))
  Downloading https://foo.bar.com/artifactory/api/pypi/aggregate-pypi/packages/b8/9c/1973e3117d43527a42f2a8afbc81e48d69a537d6e2c39412049b1592d1e2/PyJWT-1.4.2-py2.py3-none-any.whl
Collecting oauthlib>=0.6.2 (from requests-oauthlib>=0.3.3->jira->-r /src/requirements.txt (line 2))
  Downloading https://foo.bar.com/artifactory/api/pypi/aggregate-pypi/packages/ce/92/7f07412a4f04e55c1e83a09c6fd48075b5df96c1dbd4078c3407c5be1dff/oauthlib-2.0.0.tar.gz (122kB)
Collecting idna>=2.0 (from cryptography>=1.3.4->pyopenssl->-r /src/requirements.txt (line 4))
  Downloading https://foo.bar.com/artifactory/api/pypi/aggregate-pypi/packages/71/02/dee75fc3e6f7455bf69221164f94586ee13552c5f33c8002335667a3d122/idna-2.1-py2.py3-none-any.whl (54kB)
Requirement already satisfied: setuptools>=11.3 in ./build/metrics-reporting/lib/python3.5/site-packages (from cryptography>=1.3.4->pyopenssl->-r /src/requirements.txt (line 4))
Collecting cffi>=1.4.1 (from cryptography>=1.3.4->pyopenssl->-r /src/requirements.txt (line 4))
  Downloading https://foo.bar.com/artifactory/api/pypi/aggregate-pypi/packages/96/05/04379df69e617fffdbfcf0c9b3a14dfc5440fb1dd622587279638fab8a24/cffi-1.9.1-cp35-cp35m-manylinux1_x86_64.whl (398kB)
Collecting pycparser (from cffi>=1.4.1->cryptography>=1.3.4->pyopenssl->-r /src/requirements.txt (line 4))
  Downloading https://foo.bar.com/artifactory/api/pypi/aggregate-pypi/packages/be/64/1bb257ffb17d01f4a38d7ce686809a736837ad4371bcc5c42ba7a715c3ac/pycparser-2.17.tar.gz (231kB)
Building wheels for collected packages: configargparse, pycrypto, ndg-httpsclient, requests-jwt, psycopg2, tlslite, cryptography, oauthlib, pycparser
  Running setup.py bdist_wheel for configargparse: started
  Running setup.py bdist_wheel for configargparse: finished with status 'done'
  Stored in directory: /root/.cache/pip/wheels/df/92/5e/8f5ace07c022d48b47b28eefe05c8dc3301a4acf68b24bbe72
  Running setup.py bdist_wheel for pycrypto: started
  Running setup.py bdist_wheel for pycrypto: finished with status 'done'
  Stored in directory: /root/.cache/pip/wheels/36/1d/4e/3dbc7cfc32d950cd0fa05ebfdee6e5f7a37feffb937ee94502
  Running setup.py bdist_wheel for ndg-httpsclient: started
  Running setup.py bdist_wheel for ndg-httpsclient: finished with status 'done'
  Stored in directory: /root/.cache/pip/wheels/8b/5f/24/2758b64c1a9ebcafe1a5b156d1461565e6c6cb57305e60dbb5
  Running setup.py bdist_wheel for requests-jwt: started
  Running setup.py bdist_wheel for requests-jwt: finished with status 'done'
  Stored in directory: /root/.cache/pip/wheels/89/d7/22/beb8da276c5a3298d1ef4a8f54407b418914ad3fa239ca0b3c
  Running setup.py bdist_wheel for psycopg2: started
  Running setup.py bdist_wheel for psycopg2: finished with status 'done'
  Stored in directory: /root/.cache/pip/wheels/d0/bb/d9/967023056cbfe75b53359efa5ba032460d724b681ed36f8d75
  Running setup.py bdist_wheel for tlslite: started
  Running setup.py bdist_wheel for tlslite: finished with status 'done'
  Stored in directory: /root/.cache/pip/wheels/2f/8e/c8/196e4c0451309ed24e9518b649d54c97d68035e6d628b95ce9
  Running setup.py bdist_wheel for cryptography: started
  Running setup.py bdist_wheel for cryptography: finished with status 'done'
  Stored in directory: /root/.cache/pip/wheels/03/f6/96/bba75f969b2090a178e5096a640cc2c246b22c4fba2fc93c1b
  Running setup.py bdist_wheel for oauthlib: started
  Running setup.py bdist_wheel for oauthlib: finished with status 'done'
  Stored in directory: /root/.cache/pip/wheels/d5/25/2e/35043ba5c67ecd675b284950e840f3f4be90a48cd11d8f49fb
  Running setup.py bdist_wheel for pycparser: started
  Running setup.py bdist_wheel for pycparser: finished with status 'done'
  Stored in directory: /root/.cache/pip/wheels/5f/58/b1/68d12aac546272d5338c7a6be502e214f8a7b1f69d37fe8f3a
Successfully built configargparse pycrypto ndg-httpsclient requests-jwt psycopg2 tlslite cryptography oauthlib pycparser
Installing collected packages: six, idna, pyasn1, pycparser, cffi, cryptography, pyopenssl, ndg-httpsclient, requests, requests-toolbelt, oauthlib, requests-oauthlib, tlslite, jira, configargparse, pycrypto, certifi, urllib3, PyJWT, requests-jwt, psycopg2
Successfully installed PyJWT-1.4.2 certifi-2016.9.26 cffi-1.9.1 configargparse-0.11.0 cryptography-1.5.3 idna-2.1 jira-1.0.7 ndg-httpsclient-0.4.2 oauthlib-2.0.0 psycopg2-2.6.2 pyasn1-0.1.9 pycparser-2.17 pycrypto-2.6.1 pyopenssl-16.2.0 requests-2.9.2 requests-jwt-0.4 requests-oauthlib-0.7.0 requests-toolbelt-0.7.0 six-1.10.0 tlslite-0.4.9 urllib3-1.19.1
/bin/bash: prelink: command not found
Making script /src/build/metrics-reporting/bin/jwt relative
Making script /src/build/metrics-reporting/bin/pip relative
Making script /src/build/metrics-reporting/bin/jirashell relative
Making script /src/build/metrics-reporting/bin/pip3.5 relative
Making script /src/build/metrics-reporting/bin/pip3 relative
Making script /src/build/metrics-reporting/bin/wheel relative
Making script /src/build/metrics-reporting/bin/tls.py relative
Making script /src/build/metrics-reporting/bin/easy_install-3.5 relative
Making script /src/build/metrics-reporting/bin/ndg_httpclient relative
Making script /src/build/metrics-reporting/bin/tlsdb.py relative
Making script /src/build/metrics-reporting/bin/easy_install relative
{:timestamp=>"2016-11-17T14:10:24.760545+0000", :message=>"no value for epoch is set, defaulting to nil", :level=>:warn}
{:timestamp=>"2016-11-17T14:10:24.760713+0000", :message=>"Force flag given. Overwriting package at foo-1.0.1-1.x86_64.rpm", :level=>:warn}
{:timestamp=>"2016-11-17T14:10:25.231649+0000", :message=>"no value for epoch is set, defaulting to nil", :level=>:warn}
{:timestamp=>"2016-11-17T14:10:31.365834+0000", :message=>"Created package", :path=>"foo-1.0.1-1.x86_64.rpm"}
```