### PR TITLE
Add ability to specify user and group for files installed by package

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,14 @@ What's a Manifest?
 ==================
 
 defines some additional information that we'll send to ``fpm``
+
+Example
+=======
+
+    version: 0.13.0
+    name: frufyfru
+    before_install: preinstall
+    user: root
+    group: root
+    config_files:
+      /etc/frufyfru.conf: examples/frufyfru.conf

--- a/ship_it/manifest.py
+++ b/ship_it/manifest.py
@@ -49,9 +49,11 @@ class Manifest(object):
                                            self.pkg_location))]
         flags = self.get_single_flags()
 
-        # add the package user and group
+
+        # add the package user and group. Use what's specified
+        # if present, or default to virtualenv_name.
         flags.extend([('{}-{}'.format(self.pkg_type, name_type),
-                       self.virtualenv_name)
+                       self.contents.get(name_type, self.virtualenv_name))
                       for name_type in ('user', 'group')])
         flags.append(('directories', self.remote_virtualenv_path))
 

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -301,16 +301,26 @@ class TestGettingArgsAndFlags(object):
         manifest.contents['test'] = value
         assert manifest.get_bool_value('test') is expected
 
-    @mock.patch('ship_it.manifest.Manifest.get_config_args_and_flags',
-                return_value=(['cfg arg'], [('cfg', 'flag')]))
-    @mock.patch('ship_it.manifest.Manifest.get_single_flags',
-                return_value=[('single', 'flag')])
-    @mock.patch('ship_it.manifest.Manifest.get_dependency_flags',
-                return_value=[('depends', 'weird-dependency == 0.1')])
-    @mock.patch('ship_it.manifest.Manifest.get_exclude_flags',
-                return_value=[('exclude', '**.pyc'), ('exclude', '**.pyo')])
+    @pytest.mark.parametrize('cfg_update,expected_user,expected_group', [
+        ({},                'ship_it', 'ship_it'),
+        ({'user': 'root'},  'root',    'ship_it'),
+        ({'group': 'root'}, 'ship_it', 'root'),
+        ({'user': 'root',
+          'group': 'root'}, 'root', 'root'),
+    ])
+    @mock.patch('ship_it.manifest.Manifest.get_config_args_and_flags')
+    @mock.patch('ship_it.manifest.Manifest.get_single_flags')
+    @mock.patch('ship_it.manifest.Manifest.get_dependency_flags')
+    @mock.patch('ship_it.manifest.Manifest.get_exclude_flags')
     def test_get_overall_args(self, mock_excludes, mock_depends, mock_single,
-                              mock_cfg, manifest):
+                              mock_cfg, manifest, cfg_update, expected_user, expected_group):
+        # Return values must be set here, rather than in the decorator,
+        # to reset their state for each iteration.
+        mock_excludes.return_value = [('exclude', '**.pyc'), ('exclude', '**.pyo')]
+        mock_depends.return_value = [('depends', 'weird-dependency == 0.1')]
+        mock_single.return_value = [('single', 'flag')]
+        mock_cfg.return_value = (['cfg arg'], [('cfg', 'flag')])
+
         expected_args = [
             'cfg arg',
             '/test_dir/build/ship_it=/opt'
@@ -318,13 +328,14 @@ class TestGettingArgsAndFlags(object):
         expected_flags = [
             ('single', 'flag'),
             ('cfg', 'flag'),
-            ('rpm-user', 'ship_it'),
-            ('rpm-group', 'ship_it'),
+            ('rpm-user', expected_user),
+            ('rpm-group', expected_group),
             ('directories', '/opt/ship_it'),
             ('depends', 'weird-dependency == 0.1'),
             ('exclude', '**.pyc'),
             ('exclude', '**.pyo'),
         ]
+        manifest.contents.update(cfg_update)
         actual_args, actual_flags = manifest.get_args_and_flags()
         assert sorted(actual_args) == sorted(expected_args)
         assert sorted(actual_flags) == sorted(expected_flags)


### PR DESCRIPTION
The use case is I often want the files on disk to be owned by 'root'
so that even if my service (running as a non-root user named
after the virtualenv) is compromised, the attacker can't modify
the on-disk representation of the program.

New tests for this feature are included. I've confirmed that the tests
fail when the code change is not in place.

