### PR TITLE
Allow adding of arbitrary non-python-package dirs

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,22 @@ Example
     group: root
     config_files:
       /etc/frufyfru.conf: examples/frufyfru.conf
+    extra_dirs:
+      - source: extras/plugins
+        target: plugins
+
+Define extra directories
+========================
+
+To add directories outside of your python package, use `extra_dirs`.
+
+`extra_dirs` is a list. Items can either be strings or dicts with
+'source' and 'target' keys.
+
+All declarations must be relative to the project directory in both
+source and target contexts - i.e., you can't copy a folder to an
+arbitrary system directory.
+
+If an item is just a string, it will just copy the dir to the top
+level of the project directory. If it's a dict, it will copy
+"source" to "target," (again, the paths must be relative).

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,3 +42,20 @@ def install_manifest():
         name='ship_it',
         method='install',
     ))
+
+
+@pytest.fixture
+def extra_dirs_str_manifest():
+    return Manifest('/test_dir/manifest.yaml', manifest_contents=dict(
+        version='0.1.0',
+        name='ship_it',
+        extra_dirs=["foodir"]
+    ))
+
+@pytest.fixture
+def extra_dirs_dict_manifest():
+    return Manifest('/test_dir/manifest.yaml', manifest_contents=dict(
+        version='0.1.0',
+        name='ship_it',
+        extra_dirs=[{"source": "foodir", "target": "some/target/dir"}]
+    ))

--- a/tests/test_full_invocation.py
+++ b/tests/test_full_invocation.py
@@ -71,3 +71,12 @@ class TestCallingTheRightPackaging(object):
         ship_it._package_virtualenv_with_manifest(copy_manifest, 'req', 'set')
         mock_copy.assert_called_once_with('req',
                                           copy_manifest.local_package_path)
+
+
+def test_extra_dirs_manifest(extra_dirs_str_manifest, extra_dirs_dict_manifest):
+    for manifest, expected in (
+        (extra_dirs_str_manifest, '/test_dir/foodir=/opt/ship_it'),
+        (extra_dirs_dict_manifest, '/test_dir/foodir=/opt/ship_it/some/target/dir'),
+    ):
+        result = manifest.get_extra_dirs(validate_dirs_exist=False).pop()
+        assert result == expected


### PR DESCRIPTION
Hi Rob, here's the change I mentioned to support including extra directories in a package. We've been using this successfully for quite a while. @herrewig did the actual work here, I'm just doing the easy part of sending it.